### PR TITLE
Remove present_stimulus and change exports

### DIFF
--- a/src/TinnitusReconstructor.jl
+++ b/src/TinnitusReconstructor.jl
@@ -16,32 +16,24 @@ using DelimitedFiles: writedlm, readdlm
 include("funcs.jl")
 include("StimGens.jl")
 
-export UniformPrior, GaussianPrior
-export BrimijoinGaussianSmoothed, Brimijoin
-export Bernoulli, BrimijoinGaussianSmoothed
-export GaussianNoise, UniformNoise
-export GaussianNoiseNoBins, UniformNoiseNoBins
+export UniformPrior
+export GaussianPrior
+export Brimijoin
+export Bernoulli
+export BrimijoinGaussianSmoothed
+export GaussianNoise
+export UniformNoise
+export GaussianNoiseNoBins
+export UniformNoiseNoBins
 export UniformPriorWeightedSampling
 export PowerDistribution
-export build_distribution
-export get_freq
-export present_stimulus
-export play_scaled_audio
 export generate_stimuli_matrix
 export generate_stimulus
-export freq_bins
-export spect2binnedrepr, binnedrepr2spect, wav2spect
 export subject_selection_process
-export cs, gs
-export nsamples, fs, mels2hz, hz2mels
-export empty_spectrum
-export synthesize_audio
-export crop_signal, crop_signal!
-
-function present_stimulus(s::Stimgen)
-    stimuli_matrix, Fs, _, _ = generate_stimuli_matrix(s)
-    play_scaled_audio.(stimuli_matrix[:, 1], Fs)
-    return nothing
-end
+export cs
+export gs
+export spect2binnedrepr
+export binnedrepr2spect
+export wav2spect
 
 end


### PR DESCRIPTION
I removed `present_stimulus` because the website code handles that and anyone else using it can make their own version to their own specs.

Export all the stimgens, cs, gs, and spect, wav, binned, conversion functions. 