### PR TITLE
Import load and LibSndFile

### DIFF
--- a/src/funcs.jl
+++ b/src/funcs.jl
@@ -1,4 +1,6 @@
 import DSP: stft
+using FileIO: load
+import LibSndFile
 
 hz2mels(f) = 2595 * log10(1 + (f / 700))
 


### PR DESCRIPTION
Fix bug where the `.wav` files aren't being loaded into `SampleBuf`s before being processed.